### PR TITLE
fix: reorder things

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,11 @@
     <title>Vite + Vue + TS</title>
   </head>
   <body>
-    <div id="app"><!--app--></div>
+    <!-- The entry <script> must come before <div id="app"> so that hydration
+         can already happen on a partial <div id="app"> while it is being
+         streamed -->
     <script type="module" async src="/src/entry-client.ts"></script>
+
+    <div id="app"><!--app--></div>
   </body>
 </html>

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,11 +2,18 @@
 import { ref } from 'vue'
 import HelloWorld from './components/HelloWorld.vue'
 const count = ref(0)
+
+// We expect Vue to server-side render the entire template first with the
+// Suspense's fallback and an interactive button first, and then later to stream
+// <script>s that will replace the fallback with the Suspense's default.
+// However it seems that instead Vue's renderer hangs on rendering the Suspense,
+// finally rendering the entire template with the Suspense's default. The
+// fallback is never rendered, and we're not getting an interactive button while
+// the renderer is hanging.
+// See https://github.com/vikejs/vike/discussions/1318
 </script>
 
 <template>
-  <button type="button" @click="count++">count is {{ count }}</button>
-
   <Suspense>
     <template #default>
       <HelloWorld />
@@ -15,4 +22,6 @@ const count = ref(0)
       <div>Loading ...</div>
     </template>
   </Suspense>
+
+  <button type="button" @click="count++">count is {{ count }}</button>
 </template>


### PR DESCRIPTION
in order to be a reproducer showcasing https://github.com/vikejs/vike/discussions/1318

@phonzammi feel free to reject this PR as this breaks your project even more. If you reject it we can just use my fork as a reproducer for that issue.

#### Steps to reproduce

```bash
git clone https://github.com/phonzammi/vite-vue-streaming-ssr
cd vite-vue-streaming-ssr
pnpm install
pnpm run build
pnpm run preview
```

```bash
curl --no-buffer http://localhost:5173
```

#### Expected result

```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <style>/* ... */</style>
    <title>Vite + Vue + TS</title>
    <script async type="module" crossorigin src="/assets/index-f5LsvWqb.js"></script>
  </head>
  <body>
    <div id="app">
      <div id="fallback-uuid">Loading...</div>
      <!-- [Can already be made interactive because the entry script has already been delivered above.
            We call this progressive hydration.] -->
      <button type="button">count is 0</button>
    </div>

    <!-- [Hanging here several seconds] -->

    <!-- [Now streaming scripts replacing Suspense fallbacks by Suspense defaults] -->
    <script>
      document.getElementById("fallback-uuid") // ...
    </script>
  </body>
</html>
```

#### Actual result

```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <style>/* ... */</style>
    <title>Vite + Vue + TS</title>
    <script async type="module" crossorigin src="/assets/index-f5LsvWqb.js"></script>
  </head>
  <body>
    <div id="app">
      
      <!-- [Hanging here several seconds instead of rendering the Suspense's fallback and the counter
            quickly] -->
      
      <!-- [Finally rendering everything. The Suspense fallback has never been rendered.] -->
      <div class="card"><h1> Edit <code>components/HelloWorld.vue</code> to test HMR </h1></div>
      <button type="button">count is 0</button>
    </div>
  </body>
</html>
```
